### PR TITLE
Fix formula_sub args when calculating derivatives

### DIFF
--- a/lib/Algorithm/CurveFit.pm
+++ b/lib/Algorithm/CurveFit.pm
@@ -162,7 +162,7 @@ sub curve_fit {
                     my $value = $deriv->($xv, @par_values);
                     if (not defined $value) { # fall back to numeric five-point stencil
                         my $h = SQRT_EPS*$xv; my $t = $xv + $h; $h = $t-$xv; # numerics. Cf. NR
-                        $value = $formula_sub->($xv, @parameters)
+                        $value = $formula_sub->($xv, map { $_->[1] } @parameters)
                     }
                     push @ary, $value;
                 }
@@ -177,7 +177,7 @@ sub curve_fit {
                     );
                     if (not defined $value) { # fall back to numeric five-point stencil
                         my $h = SQRT_EPS*$xv; my $t = $xv + $h; $h = $t-$xv; # numerics. Cf. NR
-                        $value = $formula_sub->($xv, @parameters)
+                        $value = $formula_sub->($xv, map { $_->[1] } @parameters)
                     }
                     push @ary, $value;
                 }


### PR DESCRIPTION
As found in https://rt.cpan.org/Ticket/Display.html?id=121352 (and, I think is related to the bug in
https://rt.cpan.org/Ticket/Display.html?id=134134), the tests in `t/02_bad_deriv.t` fail on Debian systems more recent than jessie.

It turns out that the problem occurs when the input `x` data point is equal to the `x0` value from the initial guess. This condition triggers an issue with `Math::Symbolic` which returns an undefined derivative value in this case (see
https://metacpan.org/release/SMUELLER/Algorithm-CurveFit-1.05/source/lib/Algorithm/CurveFit.pm#L178). What's supposed to happen here is that the code falls back to a numerical method to calculate the derivative at this point, however incorrect arguments are passed to the closure which calculates the function value at this point (called `$function_sub`, see https://metacpan.org/release/SMUELLER/Algorithm-CurveFit-1.05/source/lib/Algorithm/CurveFit.pm#L133). Instead of being called with a list of parameter values, `$function_sub` is passed first a scalar with the current `x` value and then the array-of-arrays containg the parameter data and metadata (`@parameters`).

```perl
$value = $formula_sub->($xv, @parameters)
```

The correct call is mentioned later in the code where the residuals are calculated
(https://metacpan.org/release/SMUELLER/Algorithm-CurveFit-1.05/source/lib/Algorithm/CurveFit.pm#L196):

```perl
$formula_sub->($xdata[$_], map { $_->[1] } @parameters)
```

Because the full `@parameters` array-of-arrays is passed to `$formula_sub`, something akin to a memory location is used for the `'s'` parameter instead of its current value. This causes large numbers to appear in the $formula_sub output. On jessie systems, this number is ~2e+11 (and looks a lot like `MAX_INT32*100` (i.e. a 32 bit `MAX_INT` value multiplied by 100) and, interestingly enough, still allows the iterative algorithm to find a sensible solution. Something happened between jessie and stretch (which I've not been able to work out exactly what) which makes this outlier value now be ~9e+20 (which looks like `MAX_INT64*100`).  Because this value is so large, the algorithm "converges" to the initial guess instead of to the actual input data to fit the function to and thus the `'s'` parameter never changes from its initial guess of 4 and hence the `ok($v + $eps[$par] > $val[$par]);` test fails because 4 + its epsilon value (1.0) is 5 which is not greater than 5.15 (which is the expected value for `'s'` after curve fitting).

It really looks like the issue is due to an integer precision change, but I've not been able to find anything in the various release notes between jessie and stretch.

In the end, all one needs to do is replace

```perl
$value = $formula_sub->($xv, @parameters)
```

with

```perl
$value = $formula_sub->($xv, map { $_->[1] } @parameters)
```

and the failing test passes.